### PR TITLE
Fix #43

### DIFF
--- a/src/pychart/runner.py
+++ b/src/pychart/runner.py
@@ -22,13 +22,17 @@ def run(source: str):
 
 
 def run_prompt():
-    while True:
-        line = input("$ : ")
+    try:
+        while True:
+            line = input("$ : ")
 
-        if line == ".exit":
-            break
+            if line == ".exit":
+                break
 
-        run(line)
+            run(line)
+    except KeyboardInterrupt:
+        print()
+        exit()
 
 
 def run_file(filename: str):


### PR DESCRIPTION
Added seemles exit with `^C`,
Not that for example python does not shutdown the interactive console when you `^C` instead just printing an
exception, maybe this is better because you could use `^C` to intterupt the current task instead of the entire
console