### PR TITLE
Updated run_prompt to handle multiline statements

### DIFF
--- a/src/pychart/runner.py
+++ b/src/pychart/runner.py
@@ -25,11 +25,13 @@ def run_prompt():
     try:
         while True:
             line = input("$ : ")
+            statement = line
+            while line:
+                line = input('... ')
+                statement += '\n' + line
 
-            if line == ".exit":
-                break
+            run(statement)
 
-            run(line)
     except KeyboardInterrupt:
         print()
         exit()


### PR DESCRIPTION
Previously multiline statements were not possible because the scanner automatically appends the EOF token

Originally I thought fixing this might involve complicate syntax checking like makin sure that all '(' are
closed etc.

I think this solution is the simplest to implement, that is that: every statement is ended with a empty input
(newline).